### PR TITLE
Chat Page Improvements and Notifications Redirect

### DIFF
--- a/ajudai_django_app/ai_chatbot/ai_awnser.py
+++ b/ajudai_django_app/ai_chatbot/ai_awnser.py
@@ -58,7 +58,7 @@ def notificar_admin_problema(mensagem, chatbot_id, user, conversation):
         chatbot = ChatBot.objects.get(
                     id=chatbot_id,
                     )
-        notify.send(chatbot, recipient=user, verb={mensagem}, description=f'O cliente de numero {conversation.company_client_number} está precisando de atendimento humano.')
+        notify.send(chatbot, recipient=user, verb=mensagem, target=conversation, description=f'O cliente de numero {conversation.company_client_number} está precisando de atendimento humano.')
         return 'Um administrador recebeu uma notificação, aguarde uns instantes'
     except Exception as e:
         print(f"Erro ao notificar admin {e}", file=sys.stderr)

--- a/ajudai_django_app/templates/includes/topMenu.html
+++ b/ajudai_django_app/templates/includes/topMenu.html
@@ -1,5 +1,5 @@
 {% load static %}
-
+<link rel="stylesheet" type="text/css" href="{% static 'ajudai_django_app/css/notifications.css' %}" />
 <nav class="sb-topnav navbar navbar-expand navbar-dark bg-dark">
     <!-- Navbar Brand-->
     <!-- <a class="navbar-brand ps-3" href="index.html">Start Bootstrap</a> -->
@@ -72,7 +72,8 @@ function toggleNotificationMenu() {
 
   for (var i = 0; i < notifications.length; i++) {
     var notification = document.createElement('li');
-    notification.textContent = notifications[i].verb;
+    notification.classList.add('notification-popup-item');
+    notification.textContent = `${notifications[i].verb}`;
     notificationList.appendChild(notification);
   } 
 

--- a/ajudai_django_app/templates/includes/topMenu.html
+++ b/ajudai_django_app/templates/includes/topMenu.html
@@ -70,21 +70,57 @@ function toggleNotificationMenu() {
   var notificationList = document.getElementById('notification-list');
   const notifications = JSON.parse('{{ unread_notifications_dict|escapejs }}');
 
-  for (var i = 0; i < notifications.length; i++) {
+  for (let i = 0; i < notifications.length; i++) {
     var notification = document.createElement('li');
     notification.classList.add('notification-popup-item');
     notification.textContent = `${notifications[i].verb}`;
+    notification.addEventListener("click", ()=>{
+      handleNotificationClick(notifications[i].target_object_id, notifications[i].id);
+    })
     notificationList.appendChild(notification);
   } 
 
   //Fazer contagem de notificações de acordo com as <li>'s
-
   function updateNotificationCount() {
     var notificationCount = document.getElementById('notification-count');
     var notificationList = document.getElementById('notification-list');
     var itemCount = notificationList.getElementsByTagName('li').length;
     notificationCount.textContent = itemCount;
   }
+
+  function handleNotificationClick(targetConversaId, notificationId) {
+    fetch(`/mark_notification_as_read/${notificationId}/`, { 
+      method: 'POST' ,
+      headers: {
+        'X-CSRFToken': '{{ csrf_token }}'
+      }
+    }).catch(error => {
+      
+    });
+    
+    fetch(`/get_chat/${targetConversaId}/`)
+      .then(response => {
+          if (response.status === 200) {
+              return response.json();
+          } else {
+              console.error('Conversation does not exist.');
+          }
+      })
+      .then(data => {
+          if (data) {
+              // Data contains the response body as JSON
+              data = data.data;
+              var curent_conversation_id = data.id_conversa;
+              // Set the 'activeConversaId' in localStorage
+              localStorage.setItem('activeConversaId', curent_conversation_id);
+              // Redirect to '/minhas-conversas/' in there, the activeConversaId will be used to open the correct conversa
+              window.location.href = '/minhas-conversas/';
+          }
+      })
+      .catch(error => {
+          console.error('An error occurred while checking the conversation:', error);
+      });
+    }
   
   document.addEventListener('click', closeNotificationMenu);
   // Exemplo de adição de notificações à lista (pode ser alterado)

--- a/ajudai_django_app/templates/minhas-conversas.html
+++ b/ajudai_django_app/templates/minhas-conversas.html
@@ -120,7 +120,15 @@
 
         <div class="contacts">
           <!-- Lista de contatos disponíveis -->
-          <h2>Meus clientes</h2>
+          <h2>Meus clientes </h2>
+          <a href="{% url 'minhas-conversas' %}?order={{ conversas_order }}" id="toggleOrder" class="btn btn-link fs-5">
+            {% if conversas_order == 'asc' %}
+              Ordenar pelo mais antigo
+            {% else %}
+              Ordenar pelo mais recente
+            {% endif %}
+          
+          </a>
           <ul>
             {% for conversa in conversas %}
             <li id="contact-{{ conversa.id }}" onclick="toggleDivBackground(this)">
@@ -580,7 +588,7 @@
         });
       });
     </script>
-
+    
     <script>
       window.addEventListener('DOMContentLoaded', (event) => {
         // Função para verificar se a tela é de um dispositivo móvel

--- a/ajudai_django_app/templates/minhas-conversas.html
+++ b/ajudai_django_app/templates/minhas-conversas.html
@@ -172,7 +172,11 @@
                   {% if message.role == "user" %}
                       <div class="dialog-client">
                           <div class="message-client">
-                          <span class="sender">Cliente ({{ conversa.company_client_number }})</span>
+                            {% if  conversa.client_name %}
+                              <span class="sender">Cliente ({{ conversa.client_name }})</span> 
+                            {% else %}
+                              <span class="sender">Cliente ({{ conversa.company_client_number }})</span> 
+                            {% endif %}
                           <p>{{ message.content }}</p>
                           <span class="timestamp">{{ message.date }} {{ message.time }}</span>
                           </div>

--- a/ajudai_django_app/templates/minhas-conversas.html
+++ b/ajudai_django_app/templates/minhas-conversas.html
@@ -321,7 +321,8 @@
                         var mensagens = response.data.mensagens;
                         var nome_do_cliente = response.data.nome_do_cliente;
                         var numero_do_cliente = response.data.numero_do_cliente;
-                        
+                        var nome_do_chatbot = response.data.nome_do_chatbot;
+
                         $('#conversation-' + activeConversaId).html('');
                         mensagens.forEach(function(message) {
                             var message_html = '';
@@ -349,7 +350,7 @@
                                 <div class="dialog-response">
                                   <div class="message-response">
                                     <span class="sender">
-                                      Chatbot ou Você
+                                      ${nome_do_chatbot} ou Você
                                     </span>
                                     <p>
                                       ${message.content}

--- a/ajudai_django_app/templates/minhas-conversas.html
+++ b/ajudai_django_app/templates/minhas-conversas.html
@@ -456,7 +456,7 @@
 
     <script>
       // Função para rolar para a parte inferior
-      function scrollToBottom() {
+      function scrollToBottom2() {
         window.scrollTo({
           top: document.body.scrollHeight,
           behavior: 'auto'
@@ -465,7 +465,7 @@
   
       // Verifique a largura da tela e role para a parte inferior se for menor que um determinado ponto de interrupção (por exemplo, 768 pixels)
       if (window.innerWidth <= 768) {
-        scrollToBottom();
+        scrollToBottom2();
       }
     </script>
 

--- a/ajudai_django_app/templates/minhas-conversas.html
+++ b/ajudai_django_app/templates/minhas-conversas.html
@@ -135,7 +135,11 @@
                     />
                   </div>
                   <div class="conteudo-texto-contato">
-                    <p class="texto-contato"><strong>{{ conversa.company_client_number }}</strong></p>
+                    {% if conversa.client_name %}
+                      <p class="texto-contato"><strong>{{ conversa.client_name }}</strong></p>
+                    {% else %}
+                      <p class="texto-contato"><strong>{{ conversa.company_client_number }}</strong></p>
+                    {% endif %}
                     <p class="texto-contato">Status: {{ conversa.get_status_da_conversa_display }}</p>
                   </div>  
                 </div>

--- a/ajudai_django_app/templates/minhas-conversas.html
+++ b/ajudai_django_app/templates/minhas-conversas.html
@@ -172,37 +172,8 @@
         </div>  
         
         <div class="side-conversation">
-          {% for conversa in conversas %}
-          <div class="conversation" id="conversation-{{ conversa.id }}">
-            <!-- Diálogos com balões de conversa -->
-            {% for message in conversa.context %}
-              {% if not forloop.first %}
-                  {% if message.role == "user" %}
-                      <div class="dialog-client">
-                          <div class="message-client">
-                            {% if  conversa.client_name %}
-                              <span class="sender">Cliente ({{ conversa.client_name }})</span> 
-                            {% else %}
-                              <span class="sender">Cliente ({{ conversa.company_client_number }})</span> 
-                            {% endif %}
-                          <p>{{ message.content }}</p>
-                          <span class="timestamp">{{ message.date }} {{ message.time }}</span>
-                          </div>
-                      </div>
-                  {% elif message.role == "assistant" %}
-                      <div class="dialog-response">
-                          <div class="message-response">
-                          <span class="sender">Chatbot ou Você</span>
-                          <p>{{ message.content }}</p>
-                          <span class="timestamp">{{ message.date }} {{ message.time }}</span> 
-                          </div>
-                      </div>
-                  {% endif %}
-              {% endif %}
-            {% endfor %}
-          
-          </div>
-          {% endfor %}
+          {% comment %} AQUI IRÁ SER RENDERIZADA A CONVERSA ATUAL 
+          QUANDO O USUÁRIO CLICAR EM UM CONTATO {% endcomment %}
 
           <div class="input-reply">
             <form id="message-form" method="post">
@@ -288,7 +259,7 @@
 
       function scrollToBottom(conversationId) {
             var conversationDiv = document.getElementById("conversation-" + conversationId);
-            conversationDiv.scrollTop = conversationDiv.scrollHeight;
+            conversationDiv.scrollTop = conversationDiv.scrollHeight - conversationDiv.clientHeight;   
       }
 
       $(document).ready(function() {
@@ -296,17 +267,28 @@
 
           console.log("Retrieved activeConversaId from localStorage:", activeConversaId);
 
-
           //mostra a conversa selecionada na lateral
           $("li[id^='contact-']").click(function() {
               activeConversaId = $(this).attr('id').split('-')[1];
               var id = $(this).attr('id').split('-')[1];
               console.log("Clicked contact ID: ", id);
-              $(".conversation").hide();
-              $(".info-cliente").hide();
-              $("#conversation-" + id).show();
+              //$(".conversation").hide();
+              //$(".info-cliente").hide();
+              //$("#conversation-" + id).show();
               $(".defaultText").hide();
               $(".side-conversation").css("display", "flex");
+
+              var side_conversation = document.getElementsByClassName('side-conversation')[0];
+              //Remove old conversation
+              side_conversation.removeChild(side_conversation.firstChild);
+
+              // Criando uma nova div para a conversa
+              var conversa = document.createElement('div');
+              conversa.classList.add('conversation');
+              conversa.id = 'conversation-' + activeConversaId;
+
+              // Adicionando div no lado direito da tela
+              side_conversation.prepend(conversa);
 
               localStorage.setItem('activeConversaId', activeConversaId);
 
@@ -327,10 +309,66 @@
                       }
                   }
               });
-
-              scrollToBottom(id);
+              
+              var get_conversa_url = '/get_chat/' + activeConversaId + '/';
+              $.ajax({
+                url: get_conversa_url,
+                type: 'GET',
+                success: function(response) {
+                    if (response.status == 'success') {
+                        // Update the side conversation with the data from the response
+                       
+                        var mensagens = response.data.mensagens;
+                        var nome_do_cliente = response.data.nome_do_cliente;
+                        var numero_do_cliente = response.data.numero_do_cliente;
+                        
+                        $('#conversation-' + activeConversaId).html('');
+                        mensagens.forEach(function(message) {
+                            var message_html = '';
+                            if (message.role == 'user') {
+                                if (!nome_do_cliente) {
+                                  nome_do_cliente = numero_do_cliente
+                                  
+                                }
+                                message_html = `
+                                  <div class="dialog-client">
+                                    <div class="message-client">
+                                      <span class="sender">
+                                        Cliente (${nome_do_cliente})
+                                      </span>
+                                      <p>${message.content}</p>
+                                      <span class="timestamp">
+                                        ${message.date} ${message.time} 
+                                      </span>
+                                    </div>
+                                  </div>
+                                `;
+                
+                            } else if (message.role == 'assistant') {
+                                message_html = `
+                                <div class="dialog-response">
+                                  <div class="message-response">
+                                    <span class="sender">
+                                      Chatbot ou Você
+                                    </span>
+                                    <p>
+                                      ${message.content}
+                                    </p>
+                                    <span class="timestamp">
+                                      ${message.date} ${message.time} 
+                                    </span>
+                                  </div>
+                                </div>`;
+                            }
+                            $('#conversation-' + activeConversaId).append(message_html);
+                            
+                        });
+                    }
+                    scrollToBottom(activeConversaId);
+                }
+              });
           });
-    
+          $('#contact-' + activeConversaId).trigger('click');
           //envia nova mensagem
           $("#message-form").submit(function(event) {
               event.preventDefault();

--- a/ajudai_django_app/templates/minhas-notificacoes.html
+++ b/ajudai_django_app/templates/minhas-notificacoes.html
@@ -13,6 +13,7 @@
     <title>Meus chatbots - Ajudai</title>
     <link rel="icon" href="{% static 'image/logo-ajudai-circulo.png' %}">
     <link href="{% static 'css/styles.css' %}" rel="stylesheet" />
+    <link rel="stylesheet" type="text/css" href="{% static 'ajudai_django_app/css/notifications.css' %}" />
     <script
       src="https://use.fontawesome.com/releases/v6.3.0/js/all.js"
       crossorigin="anonymous"
@@ -43,7 +44,8 @@
       
             <div class="grid">
                 {% for notification in unread_notifications %}
-                    <div class="card" style="width: 22rem;">
+                    <div class="card notification-card" id="notification-{{notification.target.id}}" 
+                        onclick="handleNotificationClick('{{notification.target.id}}', '{{notification.id}}')" style="width: 22rem;">
                       <div class="card-body">
                         <h5 class="card-title">{{notification.verb}}</h5>
                         <h6 class="card-subtitle mb-2 text-muted">De: {{notification.actor}}</h6>
@@ -64,6 +66,45 @@
         {% include 'includes/footer.html' %}
       </div>
     </div>
+
+    <script>
+       
+      function handleNotificationClick(activeConversaId, notificationId) {
+        fetch(`/mark_notification_as_read/${notificationId}/`, { 
+          method: 'POST' ,
+          headers: {
+            'X-CSRFToken': '{{ csrf_token }}'
+          }
+        }).catch(error => {
+          
+        });
+        
+        fetch(`/get_chat/${activeConversaId}/`)
+          .then(response => {
+              if (response.status === 200) {
+                  return response.json();
+              } else {
+                  console.error('Conversation does not exist.');
+              }
+          })
+          .then(data => {
+              if (data) {
+                  // Data contains the response body as JSON
+                  data = data.data;
+                  var curent_conversation_id = data.id_conversa;
+                  // Set the 'activeConversaId' in localStorage
+                  localStorage.setItem('activeConversaId', curent_conversation_id);
+                  // Redirect to '/minhas-conversas/' in there, the activeConversaId will be used to open the correct conversa
+                  window.location.href = '/minhas-conversas/';
+              }
+          })
+          .catch(error => {
+              console.error('An error occurred while checking the conversation:', error);
+          });
+    }
+
+    </script>
+
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
       crossorigin="anonymous"

--- a/ajudai_django_app/templates/minhas-notificacoes.html
+++ b/ajudai_django_app/templates/minhas-notificacoes.html
@@ -68,8 +68,9 @@
     </div>
 
     <script>
-       
-      function handleNotificationClick(activeConversaId, notificationId) {
+      // Recebe o ID a qual conversa a notificação se refere, e o ID da notificação
+      function handleNotificationClick(targetConversaId, notificationId) {
+        // Marca notificação como lida
         fetch(`/mark_notification_as_read/${notificationId}/`, { 
           method: 'POST' ,
           headers: {
@@ -78,8 +79,8 @@
         }).catch(error => {
           
         });
-        
-        fetch(`/get_chat/${activeConversaId}/`)
+        // Pega a conversa referente a notificação e define ela como conversa ativa
+        fetch(`/get_chat/${targetConversaId}/`)
           .then(response => {
               if (response.status === 200) {
                   return response.json();

--- a/ajudai_django_app/urls.py
+++ b/ajudai_django_app/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('dashboard/', views.dashboard_view, name="dashboard"),  
     path('planos-disponiveis/', views.planos_disponiveis_view, name="planos_disponiveis"),    
     path('minhas-conversas/', views.minhas_conversas_view, name='minhas-conversas'),
+    path('get_chat/<int:id>/', views.get_chat, name='get_chat'),
     path('check_for_new_messages_to_refresh/', views.check_for_new_messages_to_refresh, name='check_for_new_messages_to_refresh'),
     path('update_last_message_shown/<int:conversa_id>/', views.update_last_message_shown, name='update_last_message_shown'),
     path('contato/', views.contato_view, name="contato"),

--- a/ajudai_django_app/utils.py
+++ b/ajudai_django_app/utils.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+
+def merge_context_and_display_time(conversas):
+    conversas_com_tempo_das_mensagens = []
+    for conversa in conversas:
+        if len(conversa.context) == len(conversa.messages_display_time):
+            merged_context = []
+            for i in range(len(conversa.context)):
+                # Merge dictionaries at the same index
+                merged_item = {**conversa.context[i], **conversa.messages_display_time[i]}
+                merged_context.append(merged_item)
+            # Replace the original context with the merged context
+            conversa.context = merged_context
+            # Append the updated conversa object to the new list
+            conversas_com_tempo_das_mensagens.append(conversa)
+        else:
+            # handle the case when the lengths don't match, e.g., log an error or raise an exception
+            pass
+    return conversas_com_tempo_das_mensagens
+
+def group_and_sort_messages(conversas, sort_order='asc'):
+    ''' 
+        Essa função recebe as conversas com data e horário nas mensagens (context)
+        e ordena tanto as conversas quanto as mensagens dentro do context
+    '''
+    
+    # Group chats that have the same client number and chatbot
+    chats_grouped_by_client_phone_number = []
+    for conversa in conversas:
+        already_inserted = False
+        if(not conversa in chats_grouped_by_client_phone_number):
+            for i in range(len(chats_grouped_by_client_phone_number)):
+                grouped_chat = chats_grouped_by_client_phone_number[i]
+                # If already exists a chat with the current chatbot and cellphone number, just append one context in another
+                if(grouped_chat.chatbot == conversa.chatbot and grouped_chat.company_client_number == conversa.company_client_number):
+                    grouped_chat.context.extend(entry for entry in conversa.context if entry['role'] in ('user', 'assistant'))
+                    if(not conversa.last_message_shown):
+                        grouped_chat.last_message_shown = conversa.last_message_shown
+                        grouped_chat.id = conversa.id
+                    already_inserted = True
+                    continue
+                
+            if(not already_inserted):
+                chats_grouped_by_client_phone_number.append(conversa)
+                
+    # Ordena mensagens em cada chat
+    for chat in chats_grouped_by_client_phone_number:
+        chat.context.sort(
+            key=lambda m:
+                datetime.combine(
+                    datetime.strptime(m['date'], '%d/%m/%Y'),
+                    datetime.time(
+                        datetime.strptime(m['time'], '%H:%M')
+                    )
+                )
+        )
+    
+    # Ordena chats pela ultima mensagem
+    chats_grouped_by_client_phone_number.sort(
+        key=lambda c: 
+            datetime.combine(
+                datetime.strptime(c.context[-1]['date'], '%d/%m/%Y'), 
+                datetime.time(
+                    datetime.strptime(c.context[-1]['time'], '%H:%M')
+                )
+            ), 
+            reverse=sort_order == 'desc'
+    )
+    
+    return chats_grouped_by_client_phone_number

--- a/ajudai_django_app/views.py
+++ b/ajudai_django_app/views.py
@@ -455,6 +455,7 @@ def get_chat(request, id):
             'mensagens': conversas[0].context,
             'nome_do_cliente': conversas[0].client_name,
             'numero_do_cliente': conversas[0].company_client_number,
+            'nome_do_chatbot': conversas[0].chatbot.nome_do_chatbot,
             'id_conversa': conversas[0].id
             
         }})

--- a/ajudai_django_app/views.py
+++ b/ajudai_django_app/views.py
@@ -378,6 +378,20 @@ def minhas_conversas_view(request):
             # handle the case when the lengths don't match, e.g., log an error or raise an exception
             pass
 
+    chats_grouped_by_client_phone_number = []
+    for index, conversa in enumerate(conversas_com_tempo_das_mensagens):
+        already_inserted = False
+        if(not conversa in chats_grouped_by_client_phone_number):
+            for i in range(len(chats_grouped_by_client_phone_number)):
+                print(chats_grouped_by_client_phone_number, index)
+                grouped_chat = chats_grouped_by_client_phone_number[i]
+                # If already exists a chat with the current chatbot and cellphone number, just append one context in another
+                if(grouped_chat.chatbot == conversa.chatbot and grouped_chat.company_client_number == conversa.company_client_number):
+                    grouped_chat.context.extend(entry for entry in conversa.context if entry['role'] in ('user', 'assistant'))
+                    already_inserted = True
+                    continue
+            if(not already_inserted):
+                chats_grouped_by_client_phone_number.append(conversa)
 
     if request.method == 'POST':
         form = MessageForm(request.POST)
@@ -402,7 +416,7 @@ def minhas_conversas_view(request):
         "tab_title" : 'Ajudai - Minhas Conversas',
         "meta_desciption" : '',
         'user' : user,
-        'conversas' : conversas_com_tempo_das_mensagens,
+        'conversas' : chats_grouped_by_client_phone_number,
         'updated_conversa_id': updated_conversa_id,
         'userIsPremium' : user.userIsPremium(),
     }

--- a/ajudai_django_app/views.py
+++ b/ajudai_django_app/views.py
@@ -394,6 +394,8 @@ def minhas_conversas_view(request):
                 # If already exists a chat with the current chatbot and cellphone number, just append one context in another
                 if(grouped_chat.chatbot == conversa.chatbot and grouped_chat.company_client_number == conversa.company_client_number):
                     grouped_chat.context.extend(entry for entry in conversa.context if entry['role'] in ('user', 'assistant'))
+                    if(not conversa.last_message_shown):
+                        grouped_chat.last_message_shown = conversa.last_message_shown
                     already_inserted = True
                     continue
             if(not already_inserted):

--- a/ajudai_django_app/views.py
+++ b/ajudai_django_app/views.py
@@ -399,6 +399,26 @@ def minhas_conversas_view(request):
             if(not already_inserted):
                 chats_grouped_by_client_phone_number.append(conversa)
 
+           
+    # Sorting conversations by messages date and time - BUTTON
+    # Get the current ordering direction from the URL, default to 'desc'
+    current_order = request.GET.get('order', 'desc')
+    # Toggle the ordering direction
+    if current_order == 'asc':
+        new_order = 'desc'
+    else:
+        new_order = 'asc'
+    chats_grouped_by_client_phone_number.sort(
+        key=lambda c: 
+            datetime.combine(
+                datetime.strptime(c.context[-1]['date'], '%d/%m/%Y'), 
+                datetime.time(
+                    datetime.strptime(c.context[-1]['time'], '%H:%M')
+                )
+            ), 
+            reverse=current_order == 'desc'
+    )
+    
     if request.method == 'POST':
         form = MessageForm(request.POST)
         if form.is_valid():
@@ -422,6 +442,7 @@ def minhas_conversas_view(request):
         "meta_desciption" : '',
         'user' : user,
         'conversas' : chats_grouped_by_client_phone_number,
+        'conversas_order': new_order,
         'updated_conversa_id': updated_conversa_id,
         'userIsPremium' : user.userIsPremium(),
     }

--- a/ajudai_django_app/views.py
+++ b/ajudai_django_app/views.py
@@ -360,7 +360,7 @@ def minhas_conversas_view(request):
             default=Value(2),
             output_field=IntegerField(),
         )
-    ).order_by('status_order', '-date', 'time')
+    ).order_by('status_order', 'date', 'time')
     
     subquery = DadosClienteCadatrado.objects.filter(
         telefone=OuterRef('company_client_number')
@@ -396,6 +396,7 @@ def minhas_conversas_view(request):
                     grouped_chat.context.extend(entry for entry in conversa.context if entry['role'] in ('user', 'assistant'))
                     if(not conversa.last_message_shown):
                         grouped_chat.last_message_shown = conversa.last_message_shown
+                        grouped_chat.id = conversa.id
                     already_inserted = True
                     continue
             if(not already_inserted):
@@ -410,6 +411,19 @@ def minhas_conversas_view(request):
         new_order = 'desc'
     else:
         new_order = 'asc'
+    
+    # Ordena mensagens em cada chat
+    for chat in chats_grouped_by_client_phone_number:
+        chat.context.sort(
+            key=lambda m:
+                datetime.combine(
+                    datetime.strptime(m['date'], '%d/%m/%Y'),
+                    datetime.time(
+                        datetime.strptime(m['time'], '%H:%M')
+                    )
+                )
+        )
+    # Ordena chats pela ultima mensagem
     chats_grouped_by_client_phone_number.sort(
         key=lambda c: 
             datetime.combine(

--- a/ajudai_django_app/views.py
+++ b/ajudai_django_app/views.py
@@ -451,12 +451,13 @@ def get_chat(request, id):
         conversas = group_and_sort_messages(conversas, 'asc')
         
         # Return a JsonResponse with the data
+        conversa = conversas[0]
         return JsonResponse({'status': 'success', 'data': {
-            'mensagens': conversas[0].context,
-            'nome_do_cliente': conversas[0].client_name,
-            'numero_do_cliente': conversas[0].company_client_number,
-            'nome_do_chatbot': conversas[0].chatbot.nome_do_chatbot,
-            'id_conversa': conversas[0].id
+            'mensagens': conversa.context,
+            'nome_do_cliente': conversa.client_name,
+            'numero_do_cliente': conversa.company_client_number,
+            'nome_do_chatbot': conversa.chatbot.nome_do_chatbot,
+            'id_conversa': conversa.id
             
         }})
     else:

--- a/ajudai_django_app/views.py
+++ b/ajudai_django_app/views.py
@@ -7,6 +7,7 @@ from ajudai_django_app.ai_chatbot.ai_tools import instructions_over_limit_error_
 from ajudai_django_app.fechamento_de_pedido.procedimento_de_fechamento import informar_loja_fechamento_pedido
 from ajudai_django_app.forms import CustomUserCreationForm, LoginForm
 from ajudai_django_app.models import Adesao_Purchase, ChatBot, Conversa, CustomUser, DadosClienteCadatrado, PaymentsForUseMadde, Pedido, Premium_User_Payment_Method_Registration, Product, register_adesao_purchase_after_webhook_confirm, register_payment_method_success_after_webhook_confirm, update_conversa_objects
+from ajudai_django_app.utils import merge_context_and_display_time, group_and_sort_messages
 from django.contrib.auth import authenticate, login, logout, update_session_auth_hash
 from ajudai_django_app.payments_process.sign_in import create_stripe_customer, return_adesao_checkout_session, return_checkout_session_id, return_checkout_session_url, return_setup_future_payments_checkout_session
 from ajudai_django_app.payments_process.webhooks import HTTP_PAYMENT_API_SIGNATURE, LABEL_TO_CHECKOUT_SESSION_ID, get_session_data, get_usage_payment_webhook_customer, get_webhook_event, success_payment_checkout_and_section_recovery, success_payment_usage_charge
@@ -368,40 +369,7 @@ def minhas_conversas_view(request):
     
     conversas = conversas.annotate(client_name=Subquery(subquery))
     
-    conversas_com_tempo_das_mensagens = []
-    for conversa in conversas:
-        if len(conversa.context) == len(conversa.messages_display_time):
-            merged_context = []
-            for i in range(len(conversa.context)):
-                # Merge dictionaries at the same index
-                merged_item = {**conversa.context[i], **conversa.messages_display_time[i]}
-                merged_context.append(merged_item)
-            # Replace the original context with the merged context
-            conversa.context = merged_context
-            # Append the updated conversa object to the new list
-            conversas_com_tempo_das_mensagens.append(conversa)
-        else:
-            # handle the case when the lengths don't match, e.g., log an error or raise an exception
-            pass
-        
-    # Group chats that have the same client number and chatbot
-    chats_grouped_by_client_phone_number = []
-    for conversa in conversas_com_tempo_das_mensagens:
-        already_inserted = False
-        if(not conversa in chats_grouped_by_client_phone_number):
-            for i in range(len(chats_grouped_by_client_phone_number)):
-                grouped_chat = chats_grouped_by_client_phone_number[i]
-                # If already exists a chat with the current chatbot and cellphone number, just append one context in another
-                if(grouped_chat.chatbot == conversa.chatbot and grouped_chat.company_client_number == conversa.company_client_number):
-                    grouped_chat.context.extend(entry for entry in conversa.context if entry['role'] in ('user', 'assistant'))
-                    if(not conversa.last_message_shown):
-                        grouped_chat.last_message_shown = conversa.last_message_shown
-                        grouped_chat.id = conversa.id
-                    already_inserted = True
-                    continue
-            if(not already_inserted):
-                chats_grouped_by_client_phone_number.append(conversa)
-
+    conversas_com_tempo_das_mensagens = merge_context_and_display_time(conversas)
            
     # Sorting conversations by messages date and time - BUTTON
     # Get the current ordering direction from the URL, default to 'desc'
@@ -412,28 +380,8 @@ def minhas_conversas_view(request):
     else:
         new_order = 'asc'
     
-    # Ordena mensagens em cada chat
-    for chat in chats_grouped_by_client_phone_number:
-        chat.context.sort(
-            key=lambda m:
-                datetime.combine(
-                    datetime.strptime(m['date'], '%d/%m/%Y'),
-                    datetime.time(
-                        datetime.strptime(m['time'], '%H:%M')
-                    )
-                )
-        )
-    # Ordena chats pela ultima mensagem
-    chats_grouped_by_client_phone_number.sort(
-        key=lambda c: 
-            datetime.combine(
-                datetime.strptime(c.context[-1]['date'], '%d/%m/%Y'), 
-                datetime.time(
-                    datetime.strptime(c.context[-1]['time'], '%H:%M')
-                )
-            ), 
-            reverse=current_order == 'desc'
-    )
+    conversas = group_and_sort_messages(conversas=conversas_com_tempo_das_mensagens, sort_order=current_order)
+
     
     if request.method == 'POST':
         form = MessageForm(request.POST)
@@ -457,7 +405,7 @@ def minhas_conversas_view(request):
         "tab_title" : 'Ajudai - Minhas Conversas',
         "meta_desciption" : '',
         'user' : user,
-        'conversas' : chats_grouped_by_client_phone_number,
+        'conversas': conversas,
         'conversas_order': new_order,
         'updated_conversa_id': updated_conversa_id,
         'userIsPremium' : user.userIsPremium(),
@@ -469,8 +417,50 @@ def minhas_conversas_view(request):
     )
 
 @csrf_exempt
+def get_chat(request, id):
+    if request.method == 'GET':
+        try:
+            user = CustomUser.getUser(request)
+        except:
+            return JsonResponse({"error": "Unauthorized access"}, status=401)
 
+        if not request.user.is_authenticated:
+            return JsonResponse({"error": "Unauthorized access"}, status=401)
+        
+        # Get chat
+        conversa = get_object_or_404(Conversa, id=id)
+        
+        # Get all chats with same number and chatbot
+        chatbot = conversa.chatbot
+        conversas = Conversa.objects.filter(chatbot=chatbot).filter(company_client_number=conversa.company_client_number).annotate(
+            status_order=Case(
+                When(status_da_conversa=STATUS_CONVERSA_EM_ANDAMENTO, then=Value(1)),
+                default=Value(2),
+                output_field=IntegerField(),
+            )
+        ).order_by('status_order', 'date', 'time')
+        
+        # Get client name
+        subquery = DadosClienteCadatrado.objects.filter(
+            telefone=OuterRef('company_client_number')
+        ).values('nome')[:1]
+        conversas = conversas.annotate(client_name=Subquery(subquery))
+        
+        # Merging and displaying time
+        conversas = merge_context_and_display_time(conversas)
+        conversas = group_and_sort_messages(conversas, 'asc')
+        
+        # Return a JsonResponse with the data
+        return JsonResponse({'status': 'success', 'data': {
+            'mensagens': conversas[0].context,
+            'nome_do_cliente': conversas[0].client_name,
+            'numero_do_cliente': conversas[0].company_client_number
+            
+        }})
+    else:
+        return JsonResponse({'status': 'error', 'message': 'Invalid request method'})
 
+@csrf_exempt
 def check_for_new_messages_to_refresh(request):
     if request.method == 'POST':
         try:

--- a/ajudai_django_app/views.py
+++ b/ajudai_django_app/views.py
@@ -24,7 +24,7 @@ import json
 from django.shortcuts import get_object_or_404
 from django_q.tasks import async_task
 from django.utils import timezone
-from django.db.models import Case, When, Value, IntegerField
+from django.db.models import Case, When, Value, IntegerField, Subquery, OuterRef
 from django.core.exceptions import ObjectDoesNotExist
 from datetime import datetime, timedelta
 from django.db.models.functions import ExtractYear, ExtractMonth
@@ -361,7 +361,13 @@ def minhas_conversas_view(request):
             output_field=IntegerField(),
         )
     ).order_by('status_order', 'date', 'time')
-
+    
+    subquery = DadosClienteCadatrado.objects.filter(
+        telefone=OuterRef('company_client_number')
+    ).values('nome')[:1]
+    
+    conversas = conversas.annotate(client_name=Subquery(subquery))
+    
     conversas_com_tempo_das_mensagens = []
     for conversa in conversas:
         if len(conversa.context) == len(conversa.messages_display_time):
@@ -377,13 +383,13 @@ def minhas_conversas_view(request):
         else:
             # handle the case when the lengths don't match, e.g., log an error or raise an exception
             pass
-
+        
+    # Group chats that have the same client number and chatbot
     chats_grouped_by_client_phone_number = []
-    for index, conversa in enumerate(conversas_com_tempo_das_mensagens):
+    for conversa in conversas_com_tempo_das_mensagens:
         already_inserted = False
         if(not conversa in chats_grouped_by_client_phone_number):
             for i in range(len(chats_grouped_by_client_phone_number)):
-                print(chats_grouped_by_client_phone_number, index)
                 grouped_chat = chats_grouped_by_client_phone_number[i]
                 # If already exists a chat with the current chatbot and cellphone number, just append one context in another
                 if(grouped_chat.chatbot == conversa.chatbot and grouped_chat.company_client_number == conversa.company_client_number):
@@ -408,9 +414,8 @@ def minhas_conversas_view(request):
             updated_conversa_id = None
     else:
         updated_conversa_id = None
-        
-    #Função para adicionar número do cliente no menu responsivo
     
+    #Função para adicionar número do cliente no menu responsivo
    
     context = {
         "tab_title" : 'Ajudai - Minhas Conversas',

--- a/ajudai_django_app/views.py
+++ b/ajudai_django_app/views.py
@@ -454,7 +454,8 @@ def get_chat(request, id):
         return JsonResponse({'status': 'success', 'data': {
             'mensagens': conversas[0].context,
             'nome_do_cliente': conversas[0].client_name,
-            'numero_do_cliente': conversas[0].company_client_number
+            'numero_do_cliente': conversas[0].company_client_number,
+            'id_conversa': conversas[0].id
             
         }})
     else:
@@ -1667,4 +1668,7 @@ def notifications(request):
 
 def mark_notification_as_read(request, notification_id):
     Notification.objects.filter(id=notification_id).mark_all_as_read(recipient=request.user)
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+        return HttpResponse(200)
+    
     return redirect(reverse('notifications'))

--- a/ajudai_django_app/views.py
+++ b/ajudai_django_app/views.py
@@ -360,7 +360,7 @@ def minhas_conversas_view(request):
             default=Value(2),
             output_field=IntegerField(),
         )
-    ).order_by('status_order', 'date', 'time')
+    ).order_by('status_order', '-date', 'time')
     
     subquery = DadosClienteCadatrado.objects.filter(
         telefone=OuterRef('company_client_number')

--- a/static/ajudai_django_app/css/notifications.css
+++ b/static/ajudai_django_app/css/notifications.css
@@ -1,0 +1,13 @@
+.notification-card:hover{
+    transform: scale(1.025);
+    cursor: pointer;
+    transition: transform 0.3s ease;
+}
+
+.notification-popup-item:hover{
+    background-color: #5C7AD3;
+    color: white;
+    cursor: pointer;
+    border-radius: 3px;
+    transition: transform 0.3s ease;
+}


### PR DESCRIPTION
This PR adds:

Chats page:
- Group conversations by client number and bot
- Order conversations by most/last recent
- Scroll conversations to bottom when loading the page

Notifications:
- Notifications now have a chat as target
- Redirect to chat when clicking in notifications (either in notifications page or in the bell icon)